### PR TITLE
Smol changes to grammar

### DIFF
--- a/main.java
+++ b/main.java
@@ -125,7 +125,23 @@ class Interpreter extends AbstractParseTreeVisitor<Double> implements simpleCalc
 		return 0.0;
 	}
 
-	public Double visitCond(simpleCalcParser.CondContext ctx) {
+	public Double visitNegation(simpleCalcParser.NegationContext ctx) {
+		return 0.0;
+	}
+
+	public Double visitComparison(simpleCalcParser.ComparisonContext ctx) {
+		return 0.0;
+	}
+
+	public Double visitAndOr(simpleCalcParser.AndOrContext ctx) {
+		return 0.0;
+	}
+
+	public Double visitOneliner(simpleCalcParser.OnelinerContext ctx) {
+		return 0.0;
+	}
+
+	public Double visitScope(simpleCalcParser.ScopeContext ctx) {
 		return 0.0;
 	}
 }

--- a/main.java
+++ b/main.java
@@ -60,11 +60,11 @@ class Interpreter extends AbstractParseTreeVisitor<Double> implements simpleCalc
 		for (simpleCalcParser.StmtContext a : ctx.s)
 			visit(a);
 		return visit(ctx.e);
-	};
+	}
 
 	public Double visitParenthesis(simpleCalcParser.ParenthesisContext ctx) {
 		return visit(ctx.e);
-	};
+	}
 
 	public Double visitVariable(simpleCalcParser.VariableContext ctx) {
 		// New implementation: look up the value of the variable in the environment env:
@@ -75,29 +75,29 @@ class Interpreter extends AbstractParseTreeVisitor<Double> implements simpleCalc
 			System.exit(-1);
 		}
 		return d;
-	};
+	}
 
 	public Double visitAddSub(simpleCalcParser.AddSubContext ctx) {
 		if (ctx.op.getText().equals("+"))
 			return visit(ctx.e1) + visit(ctx.e2);
 		else
 			return visit(ctx.e1) - visit(ctx.e2);
-	};
+	}
 
 	public Double visitMultDiv(simpleCalcParser.MultDivContext ctx) {
 		if (ctx.op.getText().equals("*"))
 			return visit(ctx.e1) * visit(ctx.e2);
 		else
 			return visit(ctx.e1) / visit(ctx.e2);
-	};
+	}
 
 	public Double visitConstant(simpleCalcParser.ConstantContext ctx) {
 		return Double.parseDouble(ctx.c.getText());
-	};
+	}
 
 	public Double visitSignedConstant(simpleCalcParser.SignedConstantContext ctx) {
 		return Double.parseDouble(ctx.getText());
-	};
+	}
 
 	public Double visitAssignment(simpleCalcParser.AssignmentContext ctx) {
 		// New implementation: evaluate the expression and store it in the environment for the given
@@ -107,11 +107,11 @@ class Interpreter extends AbstractParseTreeVisitor<Double> implements simpleCalc
 		env.put(varname, v);
 
 		return v;
-	};
+	}
 
 	public Double visitIf(simpleCalcParser.IfContext ctx) {
 		return 0.0;
-	};
+	}
 
 	public Double visitIfElse(simpleCalcParser.IfElseContext ctx) {
 		return 0.0;

--- a/simpleCalc.g4
+++ b/simpleCalc.g4
@@ -13,30 +13,30 @@ expr : x=ID						# Variable
 ;
 
 stmt : x=ID '=' e=expr						# Assignment
-	| 'if' '(' cond ')' stmts				# If
-	| 'if' '(' cond ')' stmts 'else' stmts	# IfElse
-	| 'while' '(' cond ')' stmts			# While
+	| 'if' '(' cond ')' prog				# If
+	| 'if' '(' cond ')' prog 'else' prog	# IfElse
+	| 'while' '(' cond ')' prog				# While
 ;
 
-stmts: stmt ';' stmts
-	| stmt
-	|
+stmts: stmt stmts
+	| // epsilon
 ;
 
-cond : expr ('=='|'!=') expr
-	| expr ('<'|'>') expr
-	| cond ('&&'|'||') cond
-	| '!' cond
+cond : '!' cond					# Negation
+	| expr EQ expr				# Comparison
+	| cond ('&&'|'||') cond		# AndOr
 ;
 
-//prog : stmt ';'
-//	| stmts
-//;
+prog : stmt				# Oneliner
+	| '{' stmts '}'		# Scope
+;
 
 // Lexer:
 
-OP : ('-'|'+') ; // Plus/Minus operatorer
-OP2: ('*'|'/') ; // Gange/Dividere operatorer
+OP : ('-'|'+') ; // Plus/Minus operators
+OP2: ('*'|'/') ; // Mutiply/Divide operators
+
+EQ : ('=='|'!='|'<'|'>'|'<='|'>=') ; // Equality operators
 
 ID    : ALPHA (ALPHA|NUM)* ;
 FLOAT : NUM+ ('.' NUM+)? ;

--- a/simpleCalc.g4
+++ b/simpleCalc.g4
@@ -2,8 +2,6 @@ grammar simpleCalc;
 
 start   : (s+=stmt)* e=expr EOF ;
 
-// assign : x=ID '=' e=expr  ;
-
 /* A grammar for arithmetic expressions */
 
 expr : x=ID						# Variable

--- a/simpleCalc_input.txt
+++ b/simpleCalc_input.txt
@@ -4,14 +4,14 @@ y=x*2
 z=x-y
 
 
-if ( x == 7*2 && y != 420 || !z!=9)
-    b=x+5 ; c=3*y
- else
-    b=z*-1 ; c=2*x
+if ( x == 7*2 && y != 420 || !z!=9) {
+	b=x+5 c=3*y
+} else {
+	b=z*-1 c=2*x
+}
 
-
-while ( a<3 )
-   a=a+1
-
+while ( a<3 ) {
+	a=a+1
+}
 
 z*-2


### PR DESCRIPTION
Reworked some things in the grammar, but no significant changes besides going back to using `{` & `}` for scopes with multiple statements